### PR TITLE
fix: correct variable name

### DIFF
--- a/analysis.js
+++ b/analysis.js
@@ -83,8 +83,8 @@ async function myAnalysis(context) {
   const dataAvgArray = await device.getData(avgFilter);
 
   if (dataAvgArray.length) {
-    let temperatureSum = dataAvgArray.reduce((previewsValue, currentValue) => {
-      return previewsValue + Number(currentValue.value);
+    let temperatureSum = dataAvgArray.reduce((previousValue, currentValue) => {
+      return previousValue + Number(currentValue.value);
     }, 0);
 
     temperatureSum = temperatureSum / dataAvgArray.length;


### PR DESCRIPTION
This corrects the name of a variable.
Changed from "previewsValue" to "previousValue".